### PR TITLE
Optimise allocations in ParseAccept

### DIFF
--- a/autoneg.go
+++ b/autoneg.go
@@ -50,7 +50,6 @@ import (
 type Accept struct {
 	Type, SubType string
 	Q             float64
-	Params        map[string]string
 }
 
 // acceptSlice is defined to implement sort interface.
@@ -114,7 +113,6 @@ func ParseAccept(header string) acceptSlice {
 			continue
 		}
 
-		a.Params = make(map[string]string)
 		for len(remainingPart) > 0 {
 			sp, remainingPart = nextSplitElement(remainingPart, ";")
 			sp0, spRemaining = nextSplitElement(sp, "=")
@@ -129,8 +127,6 @@ func ParseAccept(header string) acceptSlice {
 			token := strings.TrimFunc(sp0, stringTrimSpaceCutset)
 			if token == "q" {
 				a.Q, _ = strconv.ParseFloat(sp1, 32)
-			} else {
-				a.Params[token] = strings.TrimFunc(sp1, stringTrimSpaceCutset)
 			}
 		}
 

--- a/autoneg.go
+++ b/autoneg.go
@@ -40,9 +40,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package goautoneg
 
 import (
-	"sort"
 	"strconv"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
 // Structure to represent a clause in an HTTP Accept Header
@@ -54,28 +55,6 @@ type Accept struct {
 
 // acceptSlice is defined to implement sort interface.
 type acceptSlice []Accept
-
-func (slice acceptSlice) Len() int {
-	return len(slice)
-}
-
-func (slice acceptSlice) Less(i, j int) bool {
-	ai, aj := slice[i], slice[j]
-	if ai.Q > aj.Q {
-		return true
-	}
-	if ai.Type != "*" && aj.Type == "*" {
-		return true
-	}
-	if ai.SubType != "*" && aj.SubType == "*" {
-		return true
-	}
-	return false
-}
-
-func (slice acceptSlice) Swap(i, j int) {
-	slice[i], slice[j] = slice[j], slice[i]
-}
 
 func stringTrimSpaceCutset(r rune) bool {
 	return r == ' '
@@ -158,7 +137,19 @@ func ParseAccept(header string) acceptSlice {
 		accept = append(accept, a)
 	}
 
-	sort.Sort(accept)
+	slices.SortFunc(accept, func(a, b Accept) bool {
+		if a.Q > b.Q {
+			return true
+		}
+		if a.Type != "*" && b.Type == "*" {
+			return true
+		}
+		if a.SubType != "*" && b.SubType == "*" {
+			return true
+		}
+		return false
+	})
+
 	return accept
 }
 

--- a/autoneg_test.go
+++ b/autoneg_test.go
@@ -1,6 +1,7 @@
 package goautoneg
 
 import (
+	"math"
 	"testing"
 )
 
@@ -29,6 +30,56 @@ func TestNegotiate(t *testing.T) {
 	contentType = Negotiate(chrome, alternatives)
 	if contentType != "text/n3" {
 		t.Errorf("got %s expected text/n3", contentType)
+	}
+}
+
+func TestParseAccept(t *testing.T) {
+	actual := ParseAccept("application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8;otherParam=blah,image/png,*/*;q=0.5")
+	expected := []Accept{
+		{
+			Type:    "application",
+			SubType: "xml",
+			Q:       1,
+		},
+		{
+			Type:    "application",
+			SubType: "xhtml+xml",
+			Q:       1,
+		},
+		{
+			Type:    "image",
+			SubType: "png",
+			Q:       1,
+		},
+		{
+			Type:    "text",
+			SubType: "html",
+			Q:       0.9,
+		},
+		{
+			Type:    "text",
+			SubType: "plain",
+			Q:       0.8,
+		},
+		{
+			Type:    "*",
+			SubType: "*",
+			Q:       0.5,
+		},
+	}
+
+	if len(actual) != len(expected) {
+		t.Fatalf("expected %d entries, but got %d in %v", len(expected), len(actual), actual)
+	}
+
+	for i, expectedEntry := range expected {
+		actualEntry := actual[i]
+
+		qDiff := math.Abs(actualEntry.Q - expectedEntry.Q)
+
+		if actualEntry.Type != expectedEntry.Type || actualEntry.SubType != expectedEntry.SubType || qDiff > 0.0001 {
+			t.Fatalf("expected: %v\nactual: %v\nat position %d in %v", expectedEntry, actualEntry, i, actual)
+		}
 	}
 }
 

--- a/autoneg_test.go
+++ b/autoneg_test.go
@@ -31,3 +31,21 @@ func TestParseAccept(t *testing.T) {
 		t.Errorf("got %s expected text/n3", content_type)
 	}
 }
+
+func BenchmarkParseAccept(b *testing.B) {
+	scenarios := []string{
+		"",
+		"application/json",
+		"application/json,text/plain",
+		"application/json;q=0.9,text/plain",
+		chrome,
+	}
+
+	for _, scenario := range scenarios {
+		b.Run(scenario, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ParseAccept(scenario)
+			}
+		})
+	}
+}

--- a/autoneg_test.go
+++ b/autoneg_test.go
@@ -6,29 +6,29 @@ import (
 
 var chrome = "application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
 
-func TestParseAccept(t *testing.T) {
+func TestNegotiate(t *testing.T) {
 	alternatives := []string{"text/html", "image/png"}
-	content_type := Negotiate(chrome, alternatives)
-	if content_type != "image/png" {
-		t.Errorf("got %s expected image/png", content_type)
+	contentType := Negotiate(chrome, alternatives)
+	if contentType != "image/png" {
+		t.Errorf("got %s expected image/png", contentType)
 	}
 
 	alternatives = []string{"text/html", "text/plain", "text/n3"}
-	content_type = Negotiate(chrome, alternatives)
-	if content_type != "text/html" {
-		t.Errorf("got %s expected text/html", content_type)
+	contentType = Negotiate(chrome, alternatives)
+	if contentType != "text/html" {
+		t.Errorf("got %s expected text/html", contentType)
 	}
 
 	alternatives = []string{"text/n3", "text/plain"}
-	content_type = Negotiate(chrome, alternatives)
-	if content_type != "text/plain" {
-		t.Errorf("got %s expected text/plain", content_type)
+	contentType = Negotiate(chrome, alternatives)
+	if contentType != "text/plain" {
+		t.Errorf("got %s expected text/plain", contentType)
 	}
 
 	alternatives = []string{"text/n3", "application/rdf+xml"}
-	content_type = Negotiate(chrome, alternatives)
-	if content_type != "text/n3" {
-		t.Errorf("got %s expected text/n3", content_type)
+	contentType = Negotiate(chrome, alternatives)
+	if contentType != "text/n3" {
+		t.Errorf("got %s expected text/n3", contentType)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/munnerz/goautoneg
+
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/munnerz/goautoneg
 
 go 1.18
+
+require golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=


### PR DESCRIPTION
This PR contains two small optimisations that overall produce the following improvements to `ParseAccept`:

```
goos: darwin
goarch: arm64
pkg: github.com/munnerz/goautoneg
                                                                                                          │ original.txt │              new.txt               │
                                                                                                          │    sec/op    │   sec/op     vs base               │
ParseAccept/#00-10                                                                                          24.445n ± 0%   6.540n ± 1%  -73.25% (p=0.002 n=6)
ParseAccept/application/json-10                                                                              90.67n ± 1%   66.41n ± 1%  -26.75% (p=0.002 n=6)
ParseAccept/application/json,text/plain-10                                                                   152.7n ± 1%   123.7n ± 1%  -18.99% (p=0.002 n=6)
ParseAccept/application/json;q=0.9,text/plain-10                                                             214.5n ± 0%   164.5n ± 1%  -23.29% (p=0.002 n=6)
ParseAccept/application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5-10    636.6n ± 1%   528.9n ± 0%  -16.92% (p=0.002 n=6)

                                                                                                          │ original.txt │                new.txt                 │
                                                                                                          │     B/op     │    B/op     vs base                    │
ParseAccept/#00-10                                                                                            24.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
ParseAccept/application/json-10                                                                               72.00 ± 0%   48.00 ± 0%   -33.33% (p=0.002 n=6)
ParseAccept/application/json,text/plain-10                                                                   120.00 ± 0%   80.00 ± 0%   -33.33% (p=0.002 n=6)
ParseAccept/application/json;q=0.9,text/plain-10                                                             168.00 ± 0%   80.00 ± 0%   -52.38% (p=0.002 n=6)
ParseAccept/application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5-10     456.0 ± 0%   240.0 ± 0%   -47.37% (p=0.002 n=6)

                                                                                                          │ original.txt │                new.txt                 │
                                                                                                          │  allocs/op   │ allocs/op   vs base                    │
ParseAccept/#00-10                                                                                            1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
ParseAccept/application/json-10                                                                               2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.002 n=6)
ParseAccept/application/json,text/plain-10                                                                    2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.002 n=6)
ParseAccept/application/json;q=0.9,text/plain-10                                                              3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.002 n=6)
ParseAccept/application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5-10     5.000 ± 0%   1.000 ± 0%   -80.00% (p=0.002 n=6)

```

The first optimisation (9895b45) uses `golang.org/x/exp/slices.SortFunc` instead of `sort.Sort`. This requires Go 1.18+ as it uses generics.

The second optimisation (7248a2f) drops parsing of parameters. According to [the spec](https://httpwg.org/specs/rfc9110.html#field.accept), this is no longer widely used. Dropping this parsing has the benefit of not needing to allocate for the `Accept.Params` field. Headers that contain parameters will still be correctly parsed.