### PR TITLE
Optimise allocations in ParseAccept

### DIFF
--- a/autoneg.go
+++ b/autoneg.go
@@ -50,6 +50,7 @@ import (
 type Accept struct {
 	Type, SubType string
 	Q             float64
+	Params        map[string]string
 }
 
 // acceptSlice is defined to implement sort interface.
@@ -113,6 +114,7 @@ func ParseAccept(header string) acceptSlice {
 			continue
 		}
 
+		a.Params = make(map[string]string)
 		for len(remainingPart) > 0 {
 			sp, remainingPart = nextSplitElement(remainingPart, ";")
 			sp0, spRemaining = nextSplitElement(sp, "=")
@@ -127,6 +129,8 @@ func ParseAccept(header string) acceptSlice {
 			token := strings.TrimFunc(sp0, stringTrimSpaceCutset)
 			if token == "q" {
 				a.Q, _ = strconv.ParseFloat(sp1, 32)
+			} else {
+				a.Params[token] = strings.TrimFunc(sp1, stringTrimSpaceCutset)
 			}
 		}
 

--- a/autoneg.go
+++ b/autoneg.go
@@ -133,17 +133,17 @@ func ParseAccept(header string) acceptSlice {
 		accept = append(accept, a)
 	}
 
-	slices.SortFunc(accept, func(a, b Accept) bool {
+	slices.SortFunc(accept, func(a, b Accept) int {
 		if a.Q > b.Q {
-			return true
+			return -1
 		}
 		if a.Type != "*" && b.Type == "*" {
-			return true
+			return -1
 		}
 		if a.SubType != "*" && b.SubType == "*" {
-			return true
+			return -1
 		}
-		return false
+		return 1
 	})
 
 	return accept

--- a/autoneg.go
+++ b/autoneg.go
@@ -50,7 +50,6 @@ import (
 type Accept struct {
 	Type, SubType string
 	Q             float64
-	Params        map[string]string
 }
 
 // acceptSlice is defined to implement sort interface.
@@ -114,7 +113,6 @@ func ParseAccept(header string) acceptSlice {
 			continue
 		}
 
-		a.Params = make(map[string]string)
 		for len(remainingPart) > 0 {
 			sp, remainingPart = nextSplitElement(remainingPart, ";")
 			sp0, spRemaining = nextSplitElement(sp, "=")
@@ -129,8 +127,6 @@ func ParseAccept(header string) acceptSlice {
 			token := strings.TrimFunc(sp0, stringTrimSpaceCutset)
 			if token == "q" {
 				a.Q, _ = strconv.ParseFloat(sp1, 32)
-			} else {
-				a.Params[token] = strings.TrimFunc(sp1, stringTrimSpaceCutset)
 			}
 		}
 

--- a/autoneg.go
+++ b/autoneg.go
@@ -40,9 +40,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package goautoneg
 
 import (
-	"sort"
 	"strconv"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
 // Structure to represent a clause in an HTTP Accept Header
@@ -54,28 +55,6 @@ type Accept struct {
 
 // acceptSlice is defined to implement sort interface.
 type acceptSlice []Accept
-
-func (slice acceptSlice) Len() int {
-	return len(slice)
-}
-
-func (slice acceptSlice) Less(i, j int) bool {
-	ai, aj := slice[i], slice[j]
-	if ai.Q > aj.Q {
-		return true
-	}
-	if ai.Type != "*" && aj.Type == "*" {
-		return true
-	}
-	if ai.SubType != "*" && aj.SubType == "*" {
-		return true
-	}
-	return false
-}
-
-func (slice acceptSlice) Swap(i, j int) {
-	slice[i], slice[j] = slice[j], slice[i]
-}
 
 func stringTrimSpaceCutset(r rune) bool {
 	return r == ' '
@@ -158,7 +137,19 @@ func ParseAccept(header string) acceptSlice {
 		accept = append(accept, a)
 	}
 
-	sort.Sort(accept)
+	slices.SortFunc(accept, func(a, b Accept) bool {
+		if a.Q > b.Q {
+			return true
+		}
+		if a.Type != "*" && b.Type == "*" {
+			return true
+		}
+		if a.SubType != "*" && b.SubType == "*" {
+			return true
+		}
+		return false
+	})
+
 	return accept
 }
 

--- a/autoneg_test.go
+++ b/autoneg_test.go
@@ -31,3 +31,21 @@ func TestParseAccept(t *testing.T) {
 		t.Errorf("got %s expected text/n3", content_type)
 	}
 }
+
+func BenchmarkParseAccept(b *testing.B) {
+	scenarios := []string{
+		"",
+		"application/json",
+		"application/json,text/plain",
+		"application/json;q=0.9,text/plain",
+		chrome,
+	}
+
+	for _, scenario := range scenarios {
+		b.Run(scenario, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ParseAccept(scenario)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/munnerz/goautoneg
+
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/munnerz/goautoneg
 
 go 1.18
+
+require golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/munnerz/goautoneg
 
 go 1.18
 
-require golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
+require golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
 golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=


### PR DESCRIPTION
This PR is like https://github.com/munnerz/goautoneg/pull/5 but reverting back the change that removed `Params`, given it currently breaks https://github.com/prometheus/common. 

In this PR we propose to use `golang.org/x/exp/slices.SortFunc` instead of `sort.Sort`. This requires Go 1.18+ as it uses generics.